### PR TITLE
🐛 [Fix] CI env check for Ubuntu/macOS

### DIFF
--- a/.cursor/scripts/create-or-update-pr.sh
+++ b/.cursor/scripts/create-or-update-pr.sh
@@ -149,20 +149,18 @@ if [[ -n "$issue" ]]; then
   fi
 fi
 
-# Push current branch to origin and set upstream so the PR has the latest commits (and branch exists on remote when creating)
-branch="$(git rev-parse --abbrev-ref HEAD)"
-if [[ "$branch" != "HEAD" ]] && git remote get-url origin &>/dev/null; then
-  if ! git push -u origin HEAD; then
-    echo "Push failed. If your branch history was rewritten, run: git push -u origin $branch --force-with-lease" >&2
-    exit 1
-  fi
-fi
-
-# Create or update: if a PR already exists for the current branch, update it; otherwise create
+# Create or update: if a PR already exists for the current branch, update it; otherwise create.
 existing_pr=""
 existing_pr=$(gh pr view --json number -q '.number' 2>/dev/null) || true
 
 if [[ -n "$existing_pr" ]]; then
+  # gh pr edit does not push; push so the PR has the latest commits.
+  if [[ "$(git rev-parse --abbrev-ref HEAD)" != "HEAD" ]] && git remote get-url origin &>/dev/null; then
+    if ! git push; then
+      echo "Push failed. Run: git push -u origin $(git rev-parse --abbrev-ref HEAD)" >&2
+      exit 1
+    fi
+  fi
   gh pr edit "$existing_pr" --title "$full_title" --body-file "$body_to_use"
   [[ -n "$milestone" ]] && gh pr edit "$existing_pr" --milestone "$milestone"
   echo "PR #${existing_pr} updated: $full_title"
@@ -172,4 +170,4 @@ else
   gh pr create "${gh_args[@]}"
   echo "PR created: $full_title"
 fi
-gh pr view --web
+gh pr view --web 2>/dev/null || true

--- a/.cursor/skills/create-or-update-pr/SKILL.md
+++ b/.cursor/skills/create-or-update-pr/SKILL.md
@@ -5,7 +5,7 @@ description: Create or update a GitHub pull request for the current branch. Use 
 
 # Create or update a pull request
 
-Use this skill when the user wants to **create a PR** or **update an existing PR** (open or refresh a pull request from their branch). **Do not run `create-or-update-pr.sh` until the user has seen a preview and confirmed.** Uses `.cursor/scripts/create-or-update-pr.sh` (which creates a new PR or updates the existing one for the current branch). Scripts are agent-only under `.cursor/scripts/` ([agent-scripts](.cursor/rules/agent-scripts.mdc)); dependencies (e.g. `gh`) in README ([agent-dependencies](.cursor/rules/agent-dependencies.mdc)). Any preview or context file you keep (e.g. for later review) must go under `.cursor/context/` ([agent-context](.cursor/rules/agent-context.mdc)).
+Use this skill when the user wants to **create a PR** or **update an existing PR** (open or refresh a pull request from their branch). **Feature PRs must be linked to one task (issue) and thus get a milestone** — always pass `--issue N` for feature type; do not create a feature PR without a task. **Do not run `create-or-update-pr.sh` until the user has seen a preview and confirmed.** Uses `.cursor/scripts/create-or-update-pr.sh` (which creates a new PR or updates the existing one for the current branch). Scripts are agent-only under `.cursor/scripts/` ([agent-scripts](.cursor/rules/agent-scripts.mdc)); dependencies (e.g. `gh`) in README ([agent-dependencies](.cursor/rules/agent-dependencies.mdc)). Any preview or context file you keep (e.g. for later review) must go under `.cursor/context/` ([agent-context](.cursor/rules/agent-context.mdc)).
 
 **First action (do not skip):** As soon as the user asks to create or update a PR, run `bash .cursor/scripts/sync-github-tasks.sh` so `.cursor/context/tasks/state.json` is current. Then continue with the workflow.
 
@@ -34,7 +34,9 @@ If sync fails (e.g. `gh` auth or network), say so and continue only once state i
 - **Current branch:** Run `git branch --show-current` (or ask the user which branch the PR is from).
 - **Base branch:** Usually `main` or `master`; confirm with the user or infer from `git remote show origin` / default branch.
 - **Commits ahead:** Run `git rev-list --count BASE...HEAD` (e.g. `main...HEAD`) to see how many commits will be in the PR. Optionally `git log BASE..HEAD --oneline` to list them.
-- **Issue (for Development/Milestone):** The script only links an issue when you pass `--issue N`; the agent cannot know the issue number otherwise. **Establish it explicitly:** if the user said "this PR is for #7" or the branch/commits clearly reference one issue (e.g. `feature/7-bootstrap` or commit "Closes #7"), use that number. If it's not obvious, **ask the user:** "Which issue is this PR for? (issue number, or 'none'.)" Do not guess or pass an issue number from context unless the user or the branch/commits clearly tie the PR to that issue. If there is no linked issue, do not pass `--issue`.
+- **Issue (for Development/Milestone):** The script only links an issue when you pass `--issue N`; the agent cannot know the issue number otherwise.
+  - **✨ Feature PRs:** Must be linked to **exactly one task** (one issue) and thus to a **milestone** (the script sets the PR milestone from the issue’s milestone). **Always** establish the issue number and pass `--issue N` for feature PRs. If the user didn’t say which task, ask: "Which task does this feature PR close?" and **always show the options** (list tasks from `.cursor/context/tasks/TASKS.md` or `state.json`: issue number + title, e.g. "#7 [Task 0.0] Bootstrap", "#8 [Task 0.1] Interpreters…") so the user can pick. **Do not offer or accept "none"** for feature PRs — an issue number is required. Do not create a feature PR without `--issue N`.
+  - **Fix / Hotfix PRs:** Establish the issue if the user said "for #N" or branch/commits reference it; otherwise ask "Which issue does this PR close, or none?" and **always show the options** (list from TASKS.md or state.json: number + title). If the user says none, omit `--issue`.
 - If the working tree has uncommitted changes or the branch is not pushed, say so and ask whether to commit/push first or create the PR from the current state (and push after).
 
 ### 2. Draft title and body
@@ -44,10 +46,10 @@ If sync fails (e.g. `gh` auth or network), say so and continue only once state i
   - **🐛 [Fix]** — bug fix (e.g. `🐛 [Fix] Resolve login redirect loop`)
   - **🚑 [Hotfix]** — urgent production fix (e.g. `🚑 [Hotfix] Restore env fallback`)
   Propose based on the branch name and recent commits if the user doesn't specify; if unclear, ask which type (Feature / Fix / Hotfix) and the short title.
-- **Body:** Use the template that matches the PR type for **section structure only**: **`.github/PULL_REQUEST_TEMPLATE/feature.md`** (✨ [Feature]), **`fix.md`** (🐛 [Fix]), or **`hotfix.md`** (🚑 [Hotfix]). The body file must contain **only the sections**: ## 📝 Description, ## 📋 What changed, ## 🌟 Impact, ## ℹ️ Additional information, ## 🏞️ Demo (as in the template). **Do not** include the template's intro line ("Use the **title** field…") or any Issue / Development / Milestone block in the body file. Fill in each section as relevant; omit or leave placeholder when not applicable. Pass `--issue N` only when you have established the linked issue (from the user or from branch/commits); the script then adds "Closes #N" (or Fixes) to the body so GitHub fills the Development sidebar and sets the Milestone. If you don't know the issue, **ask the user** before drafting the body or running the script. If there is no linked issue, omit `--issue`.
+- **Body:** Use the template that matches the PR type for **section structure only**: **`.github/PULL_REQUEST_TEMPLATE/feature.md`** (✨ [Feature]), **`fix.md`** (🐛 [Fix]), or **`hotfix.md`** (🚑 [Hotfix]). The body file must contain **only the sections**: ## 📝 Description, ## 📋 What changed, ## 🌟 Impact, ## ℹ️ Additional information, ## 🏞️ Demo (as in the template). **Do not** include the template's intro line ("Use the **title** field…") or any Issue / Development / Milestone block in the body file. Fill in each section as relevant; omit or leave placeholder when not applicable. For **feature** PRs, you must pass `--issue N` (one task); the script adds "Closes #N" and sets Development + Milestone from the issue. For fix/hotfix, pass `--issue N` only when the PR is for that issue; otherwise omit.
 - **Base:** Branch to merge into (e.g. `main`). **Head:** Branch to merge from (current branch unless user says otherwise).
-- **Script:** `bash .cursor/scripts/create-or-update-pr.sh --type (feature|fix|hotfix) --title "Short description" [--base main] [--issue N] [--milestone "title"] --body-file path`. Pass `--issue N` only when the PR is for that issue (script injects Issue + Development + Milestone). Otherwise omit `--issue`. Write the body file with **sections only** (no intro line, no Issue/Development/Milestone). Title is auto-prefixed.
-- If the user's request is vague, ask for title, body content, and **which issue this PR is for** (e.g. "Which issue number does this PR close, or is there none?").
+- **Script:** `bash .cursor/scripts/create-or-update-pr.sh --type (feature|fix|hotfix) --title "Short description" [--base main] [--issue N] [--milestone "title"] --body-file path`. For **feature**, always include `--issue N`. For fix/hotfix, include `--issue N` only when the PR is for that issue. Write the body file with **sections only** (no intro line, no Issue/Development/Milestone). Title is auto-prefixed.
+- If the user's request is vague, ask for title, body content, and for **feature** PRs always **which task (issue) this PR closes** — and **always list the options** (from TASKS.md or state.json: #N + title). Do not offer "none" for feature. For fix/hotfix, "Which issue does this PR close, or none?" and list the options.
 
 ### 3. Show preview
 
@@ -58,7 +60,7 @@ Present a clear **preview** of the PR:
 
 - **Title:** ✨ [Feature] … | 🐛 [Fix] … | 🚑 [Hotfix] … (emoji + prefix, exactly one)
 - **Base:** main ← **Head:** feature/lint-setup (or current branch name)
-- **Body:** sections only; if an issue was confirmed, say "Linked issue: #N" in the preview (script will add Closes #N and set Development/Milestone when run with --issue N)
+- **Body:** sections only. For **feature** PRs, always show "Linked task: #N" and "Milestone: (from issue)" — do not create without an issue. For fix/hotfix, show "Linked issue: #N" only when applicable.
 ```
 
 Summarize: "I will create or update the PR from `HEAD` into `main` with this title and body. Say **yes** or **go ahead** to apply, or tell me what to change."
@@ -72,14 +74,14 @@ Summarize: "I will create or update the PR from `HEAD` into `main` with this tit
 
 Only proceed to this step after the user has replied to the preview with an explicit yes (e.g. "yes", "go ahead", "do it"). Once they confirm:
 
-1. Ensure the branch is pushed (if the repo uses a remote): `git push -u origin HEAD` or equivalent, if not already pushed.
-2. **Write the body to a file** — **sections only**: ## 📝 Description, ## 📋 What changed, ## 🌟 Impact, etc. Do not include the template's intro line or Issue/Development/Milestone in the file. Write to **`.cursor/context/`** only (per [agent-context](.cursor/rules/agent-context.mdc)), e.g. `.cursor/context/pr-body-draft.md`. If the PR is for an issue, pass `--issue N` and the script will inject Issue + Development + Milestone.
-3. Run the script with that body file (and `--issue N` only when the PR is for that issue). When `--issue N` is used, the script injects Issue line + **Development:** + **Milestone** from state:
+1. **Ensure the branch is pushed and has upstream** (so the script’s push doesn’t run in a sandbox and leave the branch without upstream). Run: `git push -u origin $(git branch --show-current)`. If the script later fails at push (e.g. in an environment without network), tell the user: "Push failed from here. Run: git push -u origin YOUR_BRANCH" so they can push and set upstream from their machine.
+2. **Write the body to a file** — **sections only**: ## 📝 Description, ## 📋 What changed, ## 🌟 Impact, etc. Do not include the template's intro line or Issue/Development/Milestone in the file. Write to **`.cursor/context/`** only (per [agent-context](.cursor/rules/agent-context.mdc)), e.g. `.cursor/context/pr-body-draft.md`. For **feature** PRs, you must have an issue number and pass `--issue N`; the script will inject Closes #N + Development + Milestone from the issue. For fix/hotfix, pass `--issue N` only when the PR is for that issue.
+3. Run the script with that body file. For **feature** PRs always pass `--issue N` (one task). When `--issue N` is used, the script injects Closes #N + **Development:** + **Milestone** from state:
 
    ```bash
    bash .cursor/scripts/create-or-update-pr.sh --type feature --title "Add linting for X" --base main --issue 7 --body-file .cursor/context/pr-body-draft.md
    ```
-   Omit `--issue N` if there is no linked issue. Use `--milestone "Title"` only to override the milestone from state.
+   For fix/hotfix, omit `--issue N` if there is no linked issue. Use `--milestone "Title"` only to override the milestone from state.
 
 4. **Delete the body file** after the script succeeds — remove the file you passed to `--body-file` (e.g. `.cursor/context/pr-body-draft.md`) so it does not remain in the repo.
 
@@ -94,7 +96,7 @@ Only proceed to this step after the user has replied to the preview with an expl
 | Title format| **Emoji + prefix** then short title. ✨ [Feature], 🐛 [Fix], 🚑 [Hotfix]. Example: `✨ [Feature] Add linting for X`. |
 | Body templates| `.github/PULL_REQUEST_TEMPLATE/` — **feature.md**, **fix.md**, **hotfix.md** for section structure. Body file = **sections only** (## 📝 Description, ## 📋 What changed, etc.). Do not include the template's intro line or Issue/Development/Milestone; script injects them with --issue N when needed. |
 | Create or update PR | Write body to a file (sections only); run `create-or-update-pr.sh --type X --title "..." [--issue N] --body-file path`. Omit --issue unless PR is for that issue; then script injects Issue + Development + Milestone. |
-| Link issues | Only when the PR is **for** that issue. Use `Closes #N` or `Relates to #N` in body and pass `--issue N` only then; otherwise omit — do not add an issue link unrelated to the PR. See [tasks-and-github](.cursor/rules/tasks-and-github.mdc). |
+| Link issues | **Feature PRs:** Must link to **one task** — always pass `--issue N`. When asking which task, **always show options** (list from TASKS.md or state.json: #N + title). No "none" for feature. **Fix/Hotfix:** Pass `--issue N` when applicable; when asking, show options; "none" allowed. See [tasks-and-github](.cursor/rules/tasks-and-github.mdc). |
 | Dependencies| GitHub CLI (gh) — see README → Project agent dependencies ([agent-dependencies](.cursor/rules/agent-dependencies.mdc)) |
 | Rules | [agent-scripts](.cursor/rules/agent-scripts.mdc) · [agent-dependencies](.cursor/rules/agent-dependencies.mdc) · [agent-context](.cursor/rules/agent-context.mdc) |
 
@@ -104,9 +106,9 @@ Only proceed to this step after the user has replied to the preview with an expl
 
 - [ ] Synced (`sync-github-tasks.sh`) so state.json is current (for Development link and milestone when using --issue).
 - [ ] Branch and base confirmed; commits pushed if needed.
-- [ ] Linked issue established (user confirmed or clear from branch/commits); title and body drafted; --issue N passed only when PR is for that issue.
+- [ ] For **feature** PRs: linked task (issue) established and `--issue N` passed; milestone comes from issue. For fix/hotfix: linked issue only when applicable.
 - [ ] Preview shown to the user (full body content).
 - [ ] User has confirmed.
-- [ ] Body written to a file (sections only; no intro line, no Issue/Development/Milestone); script run with `--body-file` (and `--issue N` only when the PR is for that issue).
+- [ ] Body written to a file (sections only); script run with `--body-file`; for feature always with `--issue N`, for fix/hotfix only when PR is for that issue.
 - [ ] Body file deleted after create/update succeeds (e.g. remove `.cursor/context/pr-body-draft.md`).
 - [ ] PR URL shared.

--- a/.github/workflows/check-environment.yml
+++ b/.github/workflows/check-environment.yml
@@ -1,7 +1,7 @@
 name: 🔍 Check environment
 
 on:
-  workflow_call:
+  workflow_dispatch:
 
 jobs:
   env:


### PR DESCRIPTION
## 📌 Version affected

Dev tooling and CI on `main` before this PR: no Gemfile/Bundler for CocoaPods; **check-environment** was not a practical manual workflow; CLI **ci** did not validate CocoaPods / Gemfile vs `ios/Podfile.lock`.

## 📝 Description

- **`.github/workflows/check-environment.yml`:** **`workflow_dispatch`** so the workflow is runnable from Actions; **two jobs** — **Ubuntu** and **macOS** — each run **`npm run cli -- ci --no-banner`** after setup.
- **`.github/actions/setup`:** **`ruby-version: ".ruby-version"`** for `ruby/setup-ruby` (valid input); Ruby + **`bundler-cache`** / **`bundle install`** when `setup_ruby: true`.
- **`Gemfile` / `Gemfile.lock`:** Pin **CocoaPods** to match **`COCOAPODS:`** in **`ios/Podfile.lock`**; lockfile **platforms** include **`arm64-darwin-22`** (GitHub macOS runners) alongside existing platforms.
- **`scripts/pod.sh` + `npm run pod`:** Run **`bundle exec pod`** from repo root with **`--project-directory=ios`**.
- **CLI (`scripts/cli`):** **doctor** / **install** / **`ci`** — CocoaPods checks (Gemfile pin, **`bundle exec pod`** or global **`pod`** vs lock), **`bundle install`** in **install** path; **`ci`** includes CocoaPods.

## 💥 Issues

None known. If the PR title still says only “manual run”, consider renaming to reflect Bundler + dual-platform CI (optional).

## 🌟 Impact

- **UX:** One supported path for pods via **Bundler**; env checks runnable on **Linux + macOS** in Actions.
- **Performance:** Negligible.
- **Security:** N/A.
- **Maintenance:** CocoaPods version aligned across **Gemfile**, **Gemfile.lock**, and **Podfile.lock**; doctor/ci catch drift.

## ℹ️ Additional information

- Locally: **`bundle install`**, then **`npm run cli -- doctor`** or **`npm run cli -- ci --no-banner`**.
- After merge: **Actions** → **🔍 Check environment** → **Run workflow** (Ubuntu + macOS jobs).

## 🏞️ Demo

N/A (tooling / CI).
